### PR TITLE
Revise setup instrs for COSS 2026

### DIFF
--- a/setup.md
+++ b/setup.md
@@ -4,21 +4,19 @@ title: Setup
 
 We will be working on a Digital Research Alliance of Canada (the Alliance) high performance compute (HPC) or virtual cluster with all the tools we will need already installed. You will need a method of connecting to either an Alliance cluster, or our virtual cluster, which means you will need a method of connecting to them using [SSH](https://docs.alliancecan.ca/wiki/SSH). SSH can be used from a terminal which we explain how to install and open in the **Ensure you can open a terminal** section below.
 
-# Alliance Account
-If you already have an Alliance account you can log into an Alliance cluster to follow along. An Alliance account will allow you to continue to use the same environment that you used during the workshop after the workshop has completed.
-* Graham: `graham.computecanada.ca`
-* Cedar: `cedar.computecanada.ca`
-* Béluga: `beluga.computecanada.ca`
-* Narval: `narval.computecanada.ca`
+# Virtual training cluster
+We provide a virtual training cluster called a "Magic Castle" for doing exercises and playing with example code. Using the Magic Castle means you and all the other students will have the same environment, which means easier troubleshooting when things go wrong--- which they sometimes do. The Magic Castle will be destroyed at the end of the course, so you don't need to worry about messing up your work environment and you can experiment freely. 
 
-### Don't have an Alliance account?
-For those who do not have an Alliance account, we will provide a virtual cluster that you can use during the workshop, however you will loose access to it shortly after.
+# Alliance Account
+If you already have an Alliance account and access to any Alliance HPC cluster, you can log into itto follow along. If you use your Alliance account you'll be able to continue to play with the example code even after the workshop has ended and we've destroyed the Magic Castle. 
 
 # Ensure you can open a terminal
-The only setup required on your laptop is ensuring you can open a Linux command line terminal.
+The only setup required on your laptop is ensuring you can open an SSH terminal.
 
 ### Windows
-[MobaXterm](http://mobaxterm.mobatek.net/) is recommended for Windows computers. Download and install MobaXterm **home installer edition**. The portable version will not keep files from one session to the next. Verify you can run mobaXterm and "start local terminal".
+You can use Windows PowerShell or Windows Cmd tool if your Windows version is not too old.  Open either one and type `ssh -V`.  You should see a response something like "OpenSSH_for_Windows_9.5p2, LibreSSL 3.8.2".  The precise version doesn't matter, so long as it isn't too old.
+
+If you have a very old version of Windows or if you get an error from `ssh -V`, then we recommend [MobaXterm](http://mobaxterm.mobatek.net/). Download and install MobaXterm **home installer edition**. Once you have MobaXterm installed, start it and then "start local terminal" therein.
 
 ### Mac/Linux
 You already have a terminal built in.
@@ -29,20 +27,15 @@ If you are a **Linux** user running Ubuntu, you should be able to press the `ctr
 
 # Test your ssh connection
 
-### If using an Alliance account
-If you are using your Alliance account make sure you can connect to an Alliance cluster. To connect to the Graham cluster for example you would use the command below.
-~~~
-$ ssh graham.computecanada.ca
-~~~
-{: .bash}
-
 ### If using our virtual cluster
-Try connecting to our virtual training cluster by running the below command in your terminal.
+To connect to our virtual training cluster, follow the instructions given in the "Magic Castle Username and Password" item on the course page, or follow the course instructor's guidance in the first few minutes of the course.
+
+### If using an Alliance account
+If you are using your Alliance account make sure you can connect to an Alliance cluster. To connect to the Nibi cluster for example you would use the command below.
 ~~~
-$ ssh user01@legacy-lang.ace-net.training
+$ ssh nibi.alliancecan.ca
 ~~~
 {: .bash}
-You should get prompted for a password. Press Ctrl+C to exit without supplying a password. We will provide one for you at the beginning of the workshop.
 
 
 {% include links.md %}


### PR DESCRIPTION
Remove references to legacy Compute Canada clusters.
Make Magic Castle setup instructions generic.